### PR TITLE
Fix Quick User Info selector

### DIFF
--- a/Chrome/js/content.js
+++ b/Chrome/js/content.js
@@ -3504,7 +3504,7 @@ var quick_user_info = {
 			    $('img.ext_quick_user_info_btn').click(function(e) {
 
 			    	//Get user profile URL
-					var url = $(this).closest("tr").find('td:eq(0) td:eq(1) a').attr('href');
+					var url = $(this).closest("tr").find('a[href^="forumuserinfo"]').attr('href');
 
 					//Fix for vip, non vip topichead height
 					var th_height = $(this).closest('.topichead').css('height').replace('px', '');


### PR DESCRIPTION
Ha a chat online jelzések ki vannak kapcsolva a td-k eltolódnak egyel, ezért inkább az attribute selectorra cseréltem.
Nem a leggyorsabb selector, de ez hozzátartozik az sg DOM-jához.

Csak megemlítem, hogy egy refactor során esetleg a gyakran selectált dolgokat lehetne cachelni és/vagy megfelelő classekkel ellátni amikor feláll az extension betöltéskor.
