### PR TITLE
Fixed message center width

### DIFF
--- a/Chrome/css/content.css
+++ b/Chrome/css/content.css
@@ -532,11 +532,11 @@
 }
 
 .ext_mc_tabs:nth-child(3) {
-	width: 200px
+	width: 340px
 }
 
 .ext_mc_pages {
-	width: 480px;
+	width: 620px;
 	display: none;
 	overflow-y: auto;
 }


### PR DESCRIPTION
A 980-as szélesítéshez nem lettek még hozzáigazítva az üzenetközpont szélességei. Ezt javítottam most.
Ilyen volt eddig:
![sdgmcwidth-1](https://f.cloud.github.com/assets/6021051/1607897/a4c9f144-54ae-11e3-9faf-367614cbc2aa.png)

Ilyen lesz a fix után:
![sdgmcwidth-2](https://f.cloud.github.com/assets/6021051/1607900/b2cdc9f0-54ae-11e3-827b-f8f17b46fe32.png)
